### PR TITLE
chore(release): add FE step 3 file management version script

### DIFF
--- a/UpdateVersion_2026_03_05_FE_FileManagement_UI.sql
+++ b/UpdateVersion_2026_03_05_FE_FileManagement_UI.sql
@@ -1,0 +1,24 @@
+-- ===================================================================
+-- Release Information for Frontend File Management UI (Step 3)
+-- Date: 2026-03-05
+-- ===================================================================
+
+USE humans;
+
+INSERT INTO fe_releases (ReleaseNumber, ReleaseDate, Description)
+VALUES ('0.9.1', NOW(), 'Frontend UI for file management: upload flow, grouped document grids, and preview popup');
+
+SET @fe_release_id = LAST_INSERT_ID();
+
+INSERT INTO fe_release_changes (ReleaseID, ChangeDescription, ChangeType)
+VALUES
+    (@fe_release_id, 'Added context menu option Bestanden on person triangle actions', 'feature'),
+    (@fe_release_id, 'Added drawer files mode with dedicated PersonFilesForm component', 'feature'),
+    (@fe_release_id, 'Implemented upload UI with scope picker (person/family)', 'feature'),
+    (@fe_release_id, 'Implemented document type dropdown with required genealogical document categories', 'feature'),
+    (@fe_release_id, 'Implemented optional year input and file picker/upload action', 'feature'),
+    (@fe_release_id, 'Implemented grouped document sections: persoonlijke documenten and familiedocumenten', 'feature'),
+    (@fe_release_id, 'Implemented thumbnail grid rendering via /api/files/{id}/thumbnail', 'feature'),
+    (@fe_release_id, 'Implemented popup preview via window.open for /api/files/{id}', 'feature'),
+    (@fe_release_id, 'Integrated frontend service calls for upload and document list endpoints', 'enhancement'),
+    (@fe_release_id, 'Added graceful fallback icon for non-image thumbnail responses', 'enhancement');


### PR DESCRIPTION
## Samenvatting
Voegt release-registratie toe voor de frontend implementatie van stap 3 (bestandenbeheer UI).

## Toegevoegd
- `UpdateVersion_2026_03_05_FE_FileManagement_UI.sql`

## Wat het script doet
- Insert in `fe_releases` (versie `0.9.1`)
- Insert changelogregels in `fe_release_changes` voor:
  - contextmenu-optie Bestanden
  - files mode in right drawer
  - upload UI (scope/documenttype/jaar/file picker)
  - groepering persoonlijke/familiedocumenten
  - thumbnails en preview popup
  - service-integratie met MW endpoints

## Uit te voeren na merge
Run:
- `BE/UpdateVersion_2026_03_05_FE_FileManagement_UI.sql`
tegen database `humans`.